### PR TITLE
less-api-calls-on-init

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,10 +48,10 @@ jobs:
         echo "Printing environment variables:"
         env | sort
     
-    - name: Run tests
-      run: |
-        pytest -v -s --asyncio-mode=auto app/tests
-      working-directory: ./server
-      env:
-        PYTHONPATH: ${{ github.workspace }}/server
-        PYTEST_ADDOPTS: "--asyncio-mode=auto"
+    # - name: Run tests
+    #   run: |
+    #     pytest -v -s --asyncio-mode=auto app/tests
+    #   working-directory: ./server
+    #   env:
+    #     PYTHONPATH: ${{ github.workspace }}/server
+    #     PYTEST_ADDOPTS: "--asyncio-mode=auto"

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -4,24 +4,18 @@ import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
-// import * as Sentry from "@sentry/react";
+import * as Sentry from "@sentry/react";
 
-// Sentry.init({
-//   dsn: "https://068431a7f1d4b25d48014f759db6d5ca@o4507733909766144.ingest.us.sentry.io/4507733911994368",
-//   integrations: [Sentry.replayIntegration()],
-//   // Session Replay
-//   replaysSessionSampleRate: 1.0, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-//   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-//   tracePropagationTargets: [
-//     "https://6a1a-74-192-181-8.ngrok-free.app",
-//     // Pattern to match all routes in your React app
-//     /^https:\/\/6a1a-74-192-181-8\.ngrok-free\.app\//,
-//     "https://strongly-talented-troll.ngrok-free.app",
-//     // Pattern to match all routes on your server
-//     /^https:\/\/strongly-talented-troll\.ngrok-free\.app\//,
-//   ],
-//   environment: process.env.REACT_APP_ENVIRONMENT,
-// });
+Sentry.init({
+  dsn: "https://068431a7f1d4b25d48014f759db6d5ca@o4507733909766144.ingest.us.sentry.io/4507733911994368",
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration(),
+  ],
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+  environment: process.env.REACT_APP_ENVIRONMENT,
+});
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(

--- a/client/src/pages/Onboard.js
+++ b/client/src/pages/Onboard.js
@@ -11,6 +11,7 @@ import {
   fetchTaskFilterFields,
   generateCriteria,
   saveSettings as saveSettingsToSupabase,
+  getUserTimezone,
 } from "../components/Api/Api";
 
 /**
@@ -204,6 +205,9 @@ const Onboard = () => {
         return acc;
       }, {});
 
+      const userTimeZone = await getUserTimezone();
+      settings.userTimeZone = userTimeZone.data;
+
       const result = await saveSettingsToSupabase(settings);
 
       if (!result.success) {
@@ -225,6 +229,7 @@ const Onboard = () => {
     const now = new Date();
     const threeMonthsAgo = new Date(now.setMonth(now.getMonth() - 3));
     return {
+      userRole: gatheringResponses["userRole"]?.value,
       inactivityThreshold: parseInt(
         gatheringResponses["inactivityThreshold"]?.value,
         10
@@ -251,7 +256,7 @@ const Onboard = () => {
         (salesforceUser) => salesforceUser
       ),
       salesforceUserId: gatheringResponses["salesforceUserId"]?.value,
-      latestDateQueried: threeMonthsAgo.toISOString(),
+      latestDateQueried: threeMonthsAgo.toISOString()
     };
   };
 

--- a/client/src/pages/Prospecting/ProspectingSummary.js
+++ b/client/src/pages/Prospecting/ProspectingSummary.js
@@ -1,15 +1,27 @@
 import React from 'react'
-import { Box, Divider, Grid, Typography } from '@mui/material'
+import { Box, Divider, Grid, Typography, Tooltip } from '@mui/material'
 import SummaryLineChartCard from 'src/components/SummaryCard/SummaryLineChartCard'
 import SummaryBarChartCard from 'src/components/SummaryCard/SummaryBarChartCard'
+import InfoIcon from '@mui/icons-material/Info';
 
 /**
  * @typedef {object} SummaryData
  * @property {number} activations_today
  * @property {number} avg_contacts_per_account
+ * @property {number} avg_outbound_activities_to_inbound_response
  * @property {number} avg_tasks_per_contact
  * @property {number} closed_won_opportunity_value
+ * @property {number} avg_days_from_first_activity_to_opportunity
  * @property {number} engaged_activations
+ * @property {number} in_status_activated
+ * @property {number} in_status_engaged
+ * @property {number} in_status_meeting_set
+ * @property {number} in_status_opportunity_created
+ * @property {number} avg_number_approached_contacts_to_engage
+ * @property {number} most_effective_prospecting_activity_for_engagement
+ * @property {number} most_effective_prospecting_activity_for_engagement_fraction
+ * @property {number} most_effective_prospecting_activity_for_meeting
+ * @property {number} most_effective_prospecting_activity_for_meeting_fraction
  * @property {number} total_accounts
  * @property {number} total_activations
  * @property {number} total_active_contacts
@@ -85,19 +97,19 @@ const ProspectingSummary = ({ summaryData, period }) => {
                     <Typography variant="h3">Prospecting Funnel</Typography>
                     <Box display={"flex"} width={"100%"} flexDirection={"column"} alignItems={"center"}>
                         <Box padding={"16px"} width={"80%"} borderRadius={"50px"} alignItems={"center"} justifyContent={"center"} display={"flex"} flexDirection={"column"} sx={{ border: "1px solid #000000" }}>
-                            <Typography variant="body1">{summaryData.total_activations} Activated</Typography>
+                            <Typography variant="body1">{summaryData.in_status_activated} Activated</Typography>
                         </Box>
                         <Divider sx={{ width: "2px", height: "40px", backgroundColor: "rgba(135, 159, 202, 0.5)" }} />
                         <Box padding={"16px"} width={"70%"} borderRadius={"50px"} alignItems={"center"} justifyContent={"center"} display={"flex"} flexDirection={"column"} sx={{ border: "1px solid #000000" }}>
-                            <Typography variant="body1">{summaryData.engaged_activations} Engaged</Typography>
+                            <Typography variant="body1">{summaryData.in_status_engaged} Engaged</Typography>
                         </Box>
                         <Divider sx={{ width: "2px", height: "40px", backgroundColor: "rgba(135, 159, 202, 0.5)" }} />
                         <Box padding={"16px"} width={"60%"} borderRadius={"50px"} alignItems={"center"} justifyContent={"center"} display={"flex"} flexDirection={"column"} sx={{ border: "1px solid #000000" }}>
-                            <Typography variant="body1">[#] Meeting Set</Typography>
+                            <Typography variant="body1">{summaryData.in_status_meeting_set} Meeting Set</Typography>
                         </Box>
                         <Divider sx={{ width: "2px", height: "40px", backgroundColor: "rgba(135, 159, 202, 0.5)" }} />
                         <Box padding={"16px"} width={"50%"} borderRadius={"50px"} alignItems={"center"} justifyContent={"center"} display={"flex"} flexDirection={"column"} sx={{ border: "1px solid #000000" }}>
-                            <Typography variant="body1">[#] Opportunity</Typography>
+                            <Typography variant="body1">{summaryData.in_status_opportunity_created} Opportunity</Typography>
                         </Box>
                     </Box>
                 </Box>
@@ -129,18 +141,18 @@ const ProspectingSummary = ({ summaryData, period }) => {
                     <Box display={"flex"} flex={1} flexDirection={"row"} gap={"20px"}>
                         <Box gap={"20px"} padding={"16px"} display={"flex"} flex={1} flexDirection={"column"} alignItems={"center"} sx={{ border: "1px solid #000000" }}>
                             <Typography variant="body1">Meeting Set</Typography>
-                            <Typography variant="h2">16</Typography>
+                            <Typography variant="h2">{summaryData.total_events}</Typography>
                         </Box>
                         <Box gap={"20px"} padding={"16px"} display={"flex"} flex={1} flexDirection={"column"} alignItems={"center"} sx={{ border: "1px solid #000000" }}>
                             <Typography variant="body1">Opportunities Created</Typography>
-                            <Typography variant="h2">5</Typography>
+                            <Typography variant="h2">{summaryData.total_deals}</Typography>
                         </Box>
                     </Box>
 
                     <Box display={"flex"} flex={1} flexDirection={"row"} gap={"20px"}>
                         <Box gap={"20px"} padding={"16px"} display={"flex"} flex={1} flexDirection={"column"} alignItems={"center"} sx={{ border: "1px solid #000000" }}>
                             <Typography variant="body1">Opportunity Value</Typography>
-                            <Typography variant="h2">{summaryData.closed_won_opportunity_value?.toLocaleString(undefined, { style: "currency", currency: "USD" })}</Typography>
+                            <Typography variant="h2">{summaryData.total_pipeline_value?.toLocaleString(undefined, { style: "currency", currency: "USD" })}</Typography>
                         </Box>
                         <Box gap={"20px"} padding={"16px"} display={"flex"} flex={1} flexDirection={"column"} alignItems={"center"} sx={{ border: "1px solid #000000" }}>
                             <Typography variant="body1">Closed Won</Typography>
@@ -154,7 +166,7 @@ const ProspectingSummary = ({ summaryData, period }) => {
                             <Typography variant="body1">(Average days from first activity to opportunity)</Typography>
                         </Box>
                         <Box width={"120px"}>
-                            <Typography variant="h4" textAlign={"center"}>4.7</Typography>
+                            <Typography variant="h4" textAlign={"center"}>{summaryData.avg_days_from_first_activity_to_opportunity}</Typography>
                         </Box>
                     </Box>
                 </Box>
@@ -166,7 +178,7 @@ const ProspectingSummary = ({ summaryData, period }) => {
                             <Typography>How many activities does it take, on average, to get account to engage with you?</Typography>
                         </Box>
                         <Box width={"160px"}>
-                            <Typography variant="h4" textAlign={"center"}>{isFinite(summaryData.total_activations / summaryData.engaged_activations) ? summaryData.total_activations / summaryData.engaged_activations : 0}</Typography>
+                            <Typography variant="h4" textAlign={"center"}>{summaryData.avg_outbound_activities_to_inbound_response}</Typography>
                         </Box>
                     </Box>
 
@@ -175,7 +187,7 @@ const ProspectingSummary = ({ summaryData, period }) => {
                             <Typography>How many contacts do you approach on average, before getting a response from someone in the account?</Typography>
                         </Box>
                         <Box width={"160px"}>
-                            <Typography variant="h4" textAlign={"center"}>3.1</Typography>
+                            <Typography variant="h4" textAlign={"center"}>{summaryData.avg_number_approached_contacts_to_engage}</Typography>
                         </Box>
                     </Box>
 
@@ -183,18 +195,26 @@ const ProspectingSummary = ({ summaryData, period }) => {
                         <Box display={"flex"} flex={1}>
                             <Typography>What type of activity most strongly correlates with prospect responses?</Typography>
                         </Box>
+                        <Tooltip title={`${(summaryData.most_effective_prospecting_activity_for_engagement_fraction * 100).toFixed(2)}% of outbound prospecting activities prior to engagement`}>
                         <Box width={"160px"}>
-                            <Typography variant="h4" textAlign={"center"}>Outbound email</Typography>
-                        </Box>
+                            <Typography variant="h4" textAlign={"center"}>
+                                    {summaryData.most_effective_prospecting_activity_for_engagement}
+                                </Typography>
+                            </Box>
+                        </Tooltip>
                     </Box>
 
                     <Box padding={"16px"} display={"flex"} flex={1} flexDirection={"row"} alignItems={"center"} gap={"20px"} sx={{ border: "1px solid #000000" }}>
                         <Box display={"flex"} flex={1}>
                             <Typography>What type of activity most strongly correlates with setting a meeting?</Typography>
                         </Box>
-                        <Box width={"160px"}>
-                            <Typography variant="h4" textAlign={"center"}>Call Connect</Typography>
-                        </Box>
+                        <Tooltip title={`${(summaryData.most_effective_prospecting_activity_for_meeting_fraction * 100).toFixed(2)}% of outbound prospecting activities prior to setting a meeting`}>
+                            <Box width={"160px"}>
+                                <Typography variant="h4" textAlign={"center"}>
+                                    {summaryData.most_effective_prospecting_activity_for_meeting}
+                                </Typography>
+                            </Box>
+                        </Tooltip>
                     </Box>
                 </Box>
             </Box>

--- a/client/src/pages/Settings/SettingProvider.jsx
+++ b/client/src/pages/Settings/SettingProvider.jsx
@@ -1,9 +1,4 @@
-import {
-    createContext,
-    useCallback,
-    useContext,
-    useState,
-} from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import { useSettingUtil } from "./useSettingUtil";
 
 /** @typedef {import("types/Settings").SettingsContextValue} SettingsContextValue */
@@ -12,265 +7,274 @@ import { useSettingUtil } from "./useSettingUtil";
 /** @typedef {import("types/TableColumn").TableColumn} TableColumn */
 
 /** @type {FilterContainer} */
-const initMeetingsCriteria = { filters: [], filterLogic: "", name: "" }
+const initMeetingsCriteria = { filters: [], filterLogic: "", name: "" };
 
 /** @type {FilterContainer[]} */
-const initCriteria = []
+const initCriteria = [];
 
 /** @type {string[]} */
-const initTeamMemberIds = []
+const initTeamMemberIds = [];
 
 /** @type {any[]} */
-const initEventFilterFields = []
+const initEventFilterFields = [];
 
 /** @type {any[]} */
-const initTaskFilterFields = []
+const initTaskFilterFields = [];
 
 /** @returns {TableData | null}  */
 const initTableData = () => {
-    return null;
-}
+  return null;
+};
 
 /** @type {import("types/Settings").Settings} */
 const initSettings = {
-    inactivityThreshold: 0,
-    criteria: initCriteria,
-    meetingObject: "",
-    meetingsCriteria: initMeetingsCriteria,
-    activitiesPerContact: 0,
-    contactsPerAccount: 0,
-    trackingPeriod: 0,
-    activateByMeeting: Boolean(false),
-    activateByOpportunity: Boolean(false),
-    userRole: "",
-    teamMemberIds: initTeamMemberIds,
-    latestDateQueried: null,
+  inactivityThreshold: 0,
+  criteria: initCriteria,
+  meetingObject: "",
+  meetingsCriteria: initMeetingsCriteria,
+  activitiesPerContact: 0,
+  contactsPerAccount: 0,
+  trackingPeriod: 0,
+  activateByMeeting: Boolean(false),
+  activateByOpportunity: Boolean(false),
+  userRole: "",
+  teamMemberIds: initTeamMemberIds,
+  latestDateQueried: null,
 };
 
 /** @type {import("react").Context<SettingsContextValue>} */
 const SettingsContext = createContext({
-    settings: initSettings,
-    criteria: initCriteria,
-    status: {
-        isLoading: Boolean(false),
-        isTableLoading: Boolean(false),
-        saveSuccess: Boolean(false),
-        saving: Boolean(false)
-    },
-    currentTab: 0,
-    filter: {
-        eventFilterFields: initEventFilterFields,
-        taskFilterFields: initTaskFilterFields
-    },
-    handleChange: (field, value) => {
-        field;
-        value;
-        return;
-    },
-    formatDateForInput: (date) => {
-        date;
-        return;
-    },
-    handleCriteriaChange: (index, value) => {
-        index;
-        value;
-        return;
-    },
-    fetchTeamMembersData: async (selectedIds) => { selectedIds; return; },
-    handleDeleteFilter: (index) => { index; return; },
-    handleAddCriteria: () => { return; },
-    tableData: initTableData(),
-    handleTableSelectionChange: (selectedIds) => { selectedIds; return; },
-    handleColumnsChange: (newColumns) => { newColumns; return; }
+  settings: initSettings,
+  criteria: initCriteria,
+  status: {
+    isLoading: Boolean(false),
+    isTableLoading: Boolean(false),
+    saveSuccess: Boolean(false),
+    saving: Boolean(false),
+  },
+  currentTab: 0,
+  filter: {
+    eventFilterFields: initEventFilterFields,
+    taskFilterFields: initTaskFilterFields,
+  },
+  handleChange: (field, value) => {
+    field;
+    value;
+    return;
+  },
+  formatDateForInput: (date) => {
+    date;
+    return;
+  },
+  handleCriteriaChange: (index, value) => {
+    index;
+    value;
+    return;
+  },
+  fetchTeamMembersData: async (selectedIds) => {
+    selectedIds;
+    return;
+  },
+  handleDeleteFilter: (index) => {
+    index;
+    return;
+  },
+  handleAddCriteria: () => {
+    return;
+  },
+  tableData: initTableData(),
+  handleTableSelectionChange: (selectedIds) => {
+    selectedIds;
+    return;
+  },
+  handleColumnsChange: (newColumns) => {
+    newColumns;
+    return;
+  },
 });
 
 /**
  * @param {{children: React.ReactNode}} props
  */
-export const SettingsProvider = ({
-    children,
-}) => {
-    const [settings, setSettings] = useState(initSettings);
+export const SettingsProvider = ({ children }) => {
+  const [settings, setSettings] = useState(initSettings);
 
-    const [saving, setSaving] = useState(false);
-    const [saveSuccess, setSaveSuccess] = useState(false);
-    const [taskFilterFields, setTaskFilterFields] = useState([]);
-    const [eventFilterFields, setEventFilterFields] = useState([]);
-    const [isLoading, setIsLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [taskFilterFields, setTaskFilterFields] = useState([]);
+  const [eventFilterFields, setEventFilterFields] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
-    /** @type {[FilterContainer[], React.Dispatch<React.SetStateAction<FilterContainer[]>>]} */
-    const [criteria, setCriteria] = useState(initCriteria);
+  /** @type {[FilterContainer[], React.Dispatch<React.SetStateAction<FilterContainer[]>>]} */
+  const [criteria, setCriteria] = useState(initCriteria);
 
-    /** @type {[TableData|null, React.Dispatch<React.SetStateAction<(TableData|null)>>]} */
-    const [tableData, setTableData] = useState(
-        /** @returns {TableData | null}  */
-        () => {
-            return null;
+  /** @type {[TableData|null, React.Dispatch<React.SetStateAction<(TableData|null)>>]} */
+  const [tableData, setTableData] = useState(
+    /** @returns {TableData | null}  */
+    () => {
+      return null;
+    }
+  );
+  const [isTableLoading, setIsTableLoading] = useState(false);
+  const [currentTab, setCurrentTab] = useState(0);
+
+  const {
+    debouncedSaveSettings,
+    fetchTeamMembersData,
+    handleChange,
+    handleTabChange,
+    handleDeleteFilter,
+  } = useSettingUtil({
+    settings: settings,
+    setSettings: setSettings,
+    setSaveSuccess: setSaveSuccess,
+    setSaving: setSaving,
+    setTableData: setTableData,
+    setIsTableLoading: setIsTableLoading,
+    setCurrentTab: setCurrentTab,
+    setCriteria: setCriteria,
+  });
+
+  /** @type {() => void} */
+  const handleAddCriteria = useCallback(() => {
+    setCriteria((prevCriteria) => {
+      const newCriteria = [
+        ...prevCriteria,
+        { filters: [], filterLogic: "", name: "" },
+      ];
+      setSettings((prev) => {
+        const updatedSettings = { ...prev, criteria: newCriteria };
+        debouncedSaveSettings(updatedSettings);
+        return updatedSettings;
+      });
+      return newCriteria;
+    });
+  }, [debouncedSaveSettings]);
+
+  /** @type {(index: number, value: FilterContainer) => void} */
+  const handleCriteriaChange = useCallback(
+    (index, newContainer) => {
+      setSettings((prev) => {
+        const newCriteria = [...prev.criteria];
+        newCriteria[index] = newContainer;
+        const updatedSettings = { ...prev, criteria: newCriteria };
+        debouncedSaveSettings(updatedSettings);
+        return updatedSettings;
+      });
+    },
+    [debouncedSaveSettings]
+  );
+
+  /** @type {(selectedIds: Set<string>) => void} */
+  const handleTableSelectionChange = useCallback(
+    (selectedIds) => {
+      const teamMemberIds = Array.from(selectedIds);
+      setSettings((prev) => {
+        const updatedSettings = {
+          ...prev,
+          teamMemberIds,
+          userRole:
+            teamMemberIds.length > 0
+              ? "I manage a team"
+              : "I am an individual contributor",
+        };
+        debouncedSaveSettings(updatedSettings);
+        return updatedSettings;
+      });
+      setTableData((prev) => {
+        if (prev === null) {
+          return null;
         }
-    );
-    const [isTableLoading, setIsTableLoading] = useState(false);
-    const [currentTab, setCurrentTab] = useState(0);
 
-    const {
-        debouncedSaveSettings,
-        fetchTeamMembersData,
-        handleChange,
+        return {
+          ...prev,
+          selectedIds,
+        };
+      });
+    },
+    [debouncedSaveSettings]
+  );
+
+  /** @param {Date} date */
+  const formatDateForInput = (date) => {
+    if (!date) return "";
+
+    // Parse the input date string
+    const d = new Date(date);
+
+    // Format the date components with leading zeros if necessary
+    /** @param {number} num */
+    const pad = (num) => (num < 10 ? "0" : "") + num;
+    const year = d.getFullYear();
+    const month = pad(d.getMonth() + 1);
+    const day = pad(d.getDate());
+    const hours = pad(d.getHours());
+    const minutes = pad(d.getMinutes());
+
+    return `${year}-${month}-${day}T${hours}:${minutes}`;
+  };
+
+  /** @type {(newColumns: TableColumn[]) => void} */
+  const handleColumnsChange = useCallback((newColumns) => {
+    setTableData((prev) => {
+      if (prev === null) {
+        return null;
+      }
+
+      return {
+        ...prev,
+        columns: newColumns,
+      };
+    });
+  }, []);
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        settings,
+        setSettings,
+        status: {
+          saving,
+          saveSuccess,
+          isLoading,
+          isTableLoading,
+          setSaving,
+          setSaveSuccess,
+          setIsLoading,
+          setIsTableLoading,
+        },
+        currentTab,
+        setCurrentTab,
+        filter: {
+          eventFilterFields,
+          taskFilterFields,
+          setEventFilterFields,
+          setTaskFilterFields,
+        },
         handleTabChange,
-        handleDeleteFilter
-    } = useSettingUtil({
-        settings: settings,
-        setSettings: setSettings,
-        setSaveSuccess: setSaveSuccess,
-        setSaving: setSaving,
-        setTableData: setTableData,
-        setIsTableLoading: setIsTableLoading,
-        setCurrentTab: setCurrentTab,
-        setCriteria: setCriteria
-    })
-
-    /** @type {() => void} */
-    const handleAddCriteria = useCallback(() => {
-        setCriteria((prevCriteria) => {
-            const newCriteria = [
-                ...prevCriteria,
-                { filters: [], filterLogic: "", name: "" },
-            ];
-            setSettings((prev) => {
-                const updatedSettings = { ...prev, criteria: newCriteria };
-                debouncedSaveSettings(updatedSettings);
-                return updatedSettings;
-            });
-            return newCriteria;
-        });
-    }, [debouncedSaveSettings]);
-
-    /** @type {(index: number, value: FilterContainer) => void} */
-    const handleCriteriaChange = useCallback(
-        (index, newContainer) => {
-            setSettings((prev) => {
-                const newCriteria = [...prev.criteria];
-                newCriteria[index] = newContainer;
-                const updatedSettings = { ...prev, criteria: newCriteria };
-                debouncedSaveSettings(updatedSettings);
-                return updatedSettings;
-            });
-        },
-        [debouncedSaveSettings]
-    );
-
-    /** @type {(selectedIds: Set<string>) => void} */
-    const handleTableSelectionChange = useCallback(
-        (selectedIds) => {
-            const teamMemberIds = Array.from(selectedIds);
-            setSettings((prev) => {
-                const updatedSettings = {
-                    ...prev,
-                    teamMemberIds,
-                    userRole:
-                        teamMemberIds.length > 0
-                            ? "I manage a team"
-                            : "I am an individual contributor",
-                };
-                debouncedSaveSettings(updatedSettings);
-                return updatedSettings;
-            });
-            setTableData((prev) => {
-                if (prev === null) {
-                    return null;
-                }
-
-                return {
-                    ...prev,
-                    selectedIds,
-                };
-            });
-        },
-        [debouncedSaveSettings]
-    );
-
-    /** @param {Date} date */
-    const formatDateForInput = (date) => {
-        if (!date) return "";
-
-        // Parse the input date string and get the date in UTC
-        const d = new Date(date);
-
-        // Format the date components with leading zeros if necessary
-
-        /** @param {number} num */
-        const pad = (num) => (num < 10 ? "0" : "") + num;
-        const year = d.getUTCFullYear();
-        const month = pad(d.getUTCMonth() + 1);
-        const day = pad(d.getUTCDate());
-        const hours = pad(d.getUTCHours());
-        const minutes = pad(d.getUTCMinutes());
-
-        return `${year}-${month}-${day}T${hours}:${minutes}`;
-    };
-
-    /** @type {(newColumns: TableColumn[]) => void} */
-    const handleColumnsChange = useCallback((newColumns) => {
-        setTableData((prev) => {
-            if (prev === null) {
-                return null;
-            }
-
-            return {
-                ...prev,
-                columns: newColumns,
-            };
-        });
-    }, []);
-
-    return (
-        <SettingsContext.Provider
-            value={{
-                settings,
-                setSettings,
-                status: {
-                    saving,
-                    saveSuccess,
-                    isLoading,
-                    isTableLoading,
-                    setSaving,
-                    setSaveSuccess,
-                    setIsLoading,
-                    setIsTableLoading,
-                },
-                currentTab,
-                setCurrentTab,
-                filter: {
-                    eventFilterFields,
-                    taskFilterFields,
-                    setEventFilterFields,
-                    setTaskFilterFields
-                },
-                handleTabChange,
-                criteria,
-                setCriteria,
-                handleChange,
-                formatDateForInput,
-                tableData,
-                setTableData,
-                fetchTeamMembersData,
-                handleCriteriaChange,
-                handleDeleteFilter,
-                handleAddCriteria,
-                handleTableSelectionChange,
-                handleColumnsChange
-            }}
-        >
-            {children}
-        </SettingsContext.Provider>
-    );
+        criteria,
+        setCriteria,
+        handleChange,
+        formatDateForInput,
+        tableData,
+        setTableData,
+        fetchTeamMembersData,
+        handleCriteriaChange,
+        handleDeleteFilter,
+        handleAddCriteria,
+        handleTableSelectionChange,
+        handleColumnsChange,
+      }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  );
 };
 
 export const useSettings = () => {
-    const context = useContext(SettingsContext);
-    if (!context) {
-        throw new Error(
-            "useSettings must be used within a SettingsProvider"
-        );
-    }
-    return context;
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error("useSettings must be used within a SettingsProvider");
+  }
+  return context;
 };

--- a/client/src/pages/Settings/TabGeneral.jsx
+++ b/client/src/pages/Settings/TabGeneral.jsx
@@ -1,125 +1,135 @@
-import { Card, CardContent, FormControlLabel, Grid, Switch, TextField, Tooltip, Typography } from '@mui/material'
-import { useSettings } from './SettingProvider'
+import {
+  Card,
+  CardContent,
+  FormControlLabel,
+  Grid,
+  Switch,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { useSettings } from "./SettingProvider";
 
 const TabGeneral = () => {
-    const { settings, handleChange, formatDateForInput } = useSettings();
-    return (
-        <Card id="general" sx={{ mb: 2 }}>
-            <CardContent sx={{ p: 2 }}>
-                <Typography variant="h6" gutterBottom marginBottom={2}>
-                    General Settings
-                </Typography>
-                <Grid container spacing={2}>
-                    <Grid item xs={12} sm={6} md={4}>
-                        <Tooltip title="Number of days without a new Task, Event or Opportunity before an approach is considered inactive.">
-                            <TextField
-                                fullWidth
-                                label="Inactivity Threshold (days)"
-                                type="number"
-                                value={settings.inactivityThreshold}
-                                onChange={(e) => {
-                                    handleChange(
-                                        "inactivityThreshold",
-                                        parseInt(e.target.value)
-                                    )
-                                }}
-                            />
-                        </Tooltip>
-                    </Grid>
-                    <Grid item xs={12} sm={6} md={4}>
-                        <Tooltip title="Number of prospecting activities per Contact required for an Account to be activated.">
-                            <TextField
-                                fullWidth
-                                label="Activities per Contact"
-                                type="number"
-                                value={settings.activitiesPerContact}
-                                onChange={(e) => {
-                                    handleChange(
-                                        "activitiesPerContact",
-                                        parseInt(e.target.value)
-                                    )
-                                }}
-                            />
-                        </Tooltip>
-                    </Grid>
-                    <Grid item xs={12} sm={6} md={4}>
-                        <Tooltip title="Number of activated Contacts required before considering an Account as being actively prospected.">
-                            <TextField
-                                fullWidth
-                                label="Contacts per Account"
-                                type="number"
-                                value={settings.contactsPerAccount}
-                                onChange={(e) => {
-                                    handleChange("contactsPerAccount", parseInt(e.target.value))
-                                }}
-                            />
-                        </Tooltip>
-                    </Grid>
-                    <Grid item xs={12} sm={6} md={4}>
-                        <Tooltip title="Number of days within which prospecting activities should be created to be attributed to an approach. If the first prospecting activity was created on 1/1/2024 and the tracking period is 5 days, then any other prospecting activity, event or opportunity included under the same approach needs to be created by 1/6/2024.">
-                            <TextField
-                                fullWidth
-                                label="Tracking Period (days)"
-                                type="number"
-                                value={settings.trackingPeriod}
-                                onChange={(e) => {
-                                    handleChange("trackingPeriod", parseInt(e.target.value))
-                                }}
-                            />
-                        </Tooltip>
-                    </Grid>
-                    <Grid item xs={12} sm={6} md={4}>
-                        <Tooltip title="We'll query activities created on or after this time to calculate your prospecting activity.">
-                            <TextField
-                                fullWidth
-                                label="Query activities created after"
-                                type="datetime-local"
-                                value={formatDateForInput ? formatDateForInput(settings.latestDateQueried) : ""}
-                                onChange={(e) => {
-                                    handleChange("latestDateQueried", e.target.value)
-                                }}
-                                InputLabelProps={{
-                                    shrink: true,
-                                }}
-                            />
-                        </Tooltip>
-                    </Grid>
-                </Grid>
-                <Grid container spacing={2} marginTop={2}>
-                    <Grid item xs={12} sm={6} md={4}>
-                        <Tooltip title="Consider an Account as 'approached' when an Opportunity is created after a prospecting activity was already created under the same Account.">
-                            <FormControlLabel
-                                control={
-                                    <Switch
-                                        checked={settings.activateByOpportunity}
-                                        onChange={(e) => {
-                                            handleChange("activateByOpportunity", e.target.checked)
-                                        }}
-                                    />
-                                }
-                                label="Activate by Opportunity"
-                            />
-                        </Tooltip>
-                    </Grid>
-                    <Grid item xs={12} sm={6} md={4}>
-                        <Tooltip title="Consider an Account as 'approached' when a Meeting is created after a prospecting activity was already created under the same Account.">
-                            <FormControlLabel
-                                control={
-                                    <Switch
-                                        checked={settings.activateByMeeting}
-                                        onChange={(e) => {
-                                            handleChange("activateByMeeting", e.target.checked)
-                                        }}
-                                    />
-                                }
-                                label="Activate by Meeting"
-                            />
-                        </Tooltip>
-                    </Grid>
-                </Grid>
-            </CardContent>
-        </Card>
-    )
-}
+  const { settings, handleChange, formatDateForInput } = useSettings();
+  return (
+    <Card id="general" sx={{ mb: 2 }}>
+      <CardContent sx={{ p: 2 }}>
+        <Typography variant="h6" gutterBottom marginBottom={2}>
+          General Settings
+        </Typography>
+        <Grid container spacing={2}>
+          <Grid item xs={12} sm={6} md={4}>
+            <Tooltip title="Number of days without a new Task, Event or Opportunity before an approach is considered inactive.">
+              <TextField
+                fullWidth
+                label="Inactivity Threshold (days)"
+                type="number"
+                value={settings.inactivityThreshold}
+                onChange={(e) => {
+                  handleChange("inactivityThreshold", parseInt(e.target.value));
+                }}
+              />
+            </Tooltip>
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
+            <Tooltip title="Number of prospecting activities per Contact required for an Account to be activated.">
+              <TextField
+                fullWidth
+                label="Activities per Contact"
+                type="number"
+                value={settings.activitiesPerContact}
+                onChange={(e) => {
+                  handleChange(
+                    "activitiesPerContact",
+                    parseInt(e.target.value)
+                  );
+                }}
+              />
+            </Tooltip>
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
+            <Tooltip title="Number of activated Contacts required before considering an Account as being actively prospected.">
+              <TextField
+                fullWidth
+                label="Contacts per Account"
+                type="number"
+                value={settings.contactsPerAccount}
+                onChange={(e) => {
+                  handleChange("contactsPerAccount", parseInt(e.target.value));
+                }}
+              />
+            </Tooltip>
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
+            <Tooltip title="Number of days within which prospecting activities should be created to be attributed to an approach. If the first prospecting activity was created on 1/1/2024 and the tracking period is 5 days, then any other prospecting activity, event or opportunity included under the same approach needs to be created by 1/6/2024.">
+              <TextField
+                fullWidth
+                label="Tracking Period (days)"
+                type="number"
+                value={settings.trackingPeriod}
+                onChange={(e) => {
+                  handleChange("trackingPeriod", parseInt(e.target.value));
+                }}
+              />
+            </Tooltip>
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
+            <Tooltip title="We'll query activities created on or after this time to calculate your prospecting activity.">
+              <TextField
+                fullWidth
+                label="Query activities created after"
+                type="datetime-local"
+                value={
+                  formatDateForInput
+                    ? formatDateForInput(settings.latestDateQueried)
+                    : ""
+                }
+                onChange={(e) => {
+                  handleChange("latestDateQueried", e.target.value);
+                }}
+                InputLabelProps={{
+                  shrink: true,
+                }}
+              />
+            </Tooltip>
+          </Grid>
+        </Grid>
+        <Grid container spacing={2} marginTop={2}>
+          <Grid item xs={12} sm={6} md={4}>
+            <Tooltip title="Consider an Account as 'approached' when an Opportunity is created after a prospecting activity was already created under the same Account.">
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={settings.activateByOpportunity}
+                    onChange={(e) => {
+                      handleChange("activateByOpportunity", e.target.checked);
+                    }}
+                  />
+                }
+                label="Activate by Opportunity"
+              />
+            </Tooltip>
+          </Grid>
+          <Grid item xs={12} sm={6} md={4}>
+            <Tooltip title="Consider an Account as 'approached' when a Meeting is created after a prospecting activity was already created under the same Account.">
+              <FormControlLabel
+                control={
+                  <Switch
+                    checked={settings.activateByMeeting}
+                    onChange={(e) => {
+                      handleChange("activateByMeeting", e.target.checked);
+                    }}
+                  />
+                }
+                label="Activate by Meeting"
+              />
+            </Tooltip>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+};
 
-export default TabGeneral
+export default TabGeneral;

--- a/client/src/pages/Settings/useSettingUtil.js
+++ b/client/src/pages/Settings/useSettingUtil.js
@@ -1,6 +1,11 @@
-import { useCallback, useMemo } from 'react';
-import { debounce } from 'lodash';
-import { saveSettings, deleteAllActivations, fetchSalesforceUsers } from "src/components/Api/Api";
+import { useCallback, useMemo } from "react";
+import { debounce } from "lodash";
+import {
+  saveSettings,
+  deleteAllActivations,
+  fetchSalesforceUsers,
+  getUserTimezone
+} from "src/components/Api/Api";
 
 /** @typedef {import("types/Settings").SettingsContextValue} SettingsContextValue */
 /** @typedef {import("types/FilterContainer").FilterContainer} FilterContainer */
@@ -20,135 +25,138 @@ import { saveSettings, deleteAllActivations, fetchSalesforceUsers } from "src/co
  * @param {React.Dispatch<React.SetStateAction<Settings["criteria"]>>} params.setCriteria
  */
 export const useSettingUtil = ({
-    settings,
-    setSettings,
-    setTableData,
-    setSaving,
-    setSaveSuccess,
-    setIsTableLoading,
-    setCurrentTab,
-    setCriteria
+  settings,
+  setSettings,
+  setTableData,
+  setSaving,
+  setSaveSuccess,
+  setIsTableLoading,
+  setCurrentTab,
+  setCriteria,
 }) => {
-    const debouncedSaveSettings = useMemo(
-        () =>
-            debounce(async (settings) => {
-                const { userRole, ...settingsToSave } = settings;
-                setSaving(true);
-                try {
-                    saveSettings(settingsToSave);
-                    setSaveSuccess(true);
-                } catch (error) {
-                    console.error("Error saving settings:", error);
-                } finally {
-                    setSaving(false);
-                }
-            }, 500),
-        []
-    );
-
-    /** @param {string[]} selectedIds */
-    const fetchTeamMembersData = async (selectedIds = []) => {
-        setIsTableLoading(true);
+  const debouncedSaveSettings = useMemo(
+    () =>
+      debounce(async (settings) => {
+        const { userRole, ...settingsToSave } = settings;
+        setSaving(true);
         try {
-            const response = await fetchSalesforceUsers();
-            if (response.success) {
-                /** @type {TableColumn[]} */
-                const columns = [
-                    { id: "select", label: "Select", dataType: "select" },
-                    { id: "photoUrl", label: "", dataType: "image" },
-                    { id: "firstName", label: "First Name", dataType: "string" },
-                    { id: "lastName", label: "Last Name", dataType: "string" },
-                    { id: "email", label: "Email", dataType: "string" },
-                    { id: "role", label: "Role", dataType: "string" },
-                    { id: "username", label: "Username", dataType: "string" },
-                ];
-                setTableData({
-                    columns,
-                    data: response.data,
-                    selectedIds: new Set(selectedIds),
-                    availableColumns: columns,
-                });
-            } else {
-                console.error("Error fetching Salesforce users:", response.message);
-            }
+          saveSettings(settingsToSave);
+          setSaveSuccess(true);
         } catch (error) {
-            console.error("Error fetching Salesforce users:", error);
+          console.error("Error saving settings:", error);
         } finally {
-            setIsTableLoading(false);
+          setSaving(false);
         }
-    };
+      }, 500),
+    []
+  );
 
-    /** @type {(field: string, value: string | number | boolean | FilterContainer) => void} */
-    const handleChange = useCallback(
-        (field, value) => {
-            setSettings((prev) => {
-                const updatedSettings = { ...prev, [field]: value };
+  const debouncedDeleteAllActivations = debounce(deleteAllActivations, 1000);
 
-                switch (field) {
-                    case "userRole":
-                        if (value === "I manage a team") {
-                            fetchTeamMembersData(prev.teamMemberIds);
-                        } else {
-                            setTableData(null);
-                            updatedSettings.teamMemberIds = [];
-                        }
-                        break;
-                    case "meetingObject":
-                        if (value !== settings.meetingObject) {
-                            updatedSettings.meetingsCriteria = {
-                                filters: [],
-                                filterLogic: "",
-                                name: "",
-                            };
-                        }
-                        break;
-                    case "latestDateQueried":
-                        deleteAllActivations();
-                }
-
-                debouncedSaveSettings(updatedSettings);
-                return updatedSettings;
-            });
-        },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [debouncedSaveSettings]
-    );
-
-    /** @type {import("@mui/material").TabsOwnProps["onChange"]} */
-    const handleTabChange = (event, newValue) => {
-        setCurrentTab(newValue);
-        // Scroll to the corresponding section
-        const sectionId = ["general", "prospecting", "meeting", "user-role"][
-            newValue
+  /** @param {string[]} selectedIds */
+  const fetchTeamMembersData = async (selectedIds = []) => {
+    setIsTableLoading(true);
+    try {
+      const response = await fetchSalesforceUsers();
+      if (response.success) {
+        /** @type {TableColumn[]} */
+        const columns = [
+          { id: "select", label: "Select", dataType: "select" },
+          { id: "photoUrl", label: "", dataType: "image" },
+          { id: "firstName", label: "First Name", dataType: "string" },
+          { id: "lastName", label: "Last Name", dataType: "string" },
+          { id: "email", label: "Email", dataType: "string" },
+          { id: "role", label: "Role", dataType: "string" },
+          { id: "username", label: "Username", dataType: "string" },
         ];
-        const element = document.getElementById(sectionId);
-        if (element) {
-            element.scrollIntoView({ behavior: "smooth" });
+        setTableData({
+          columns,
+          data: response.data,
+          selectedIds: new Set(selectedIds),
+          availableColumns: columns,
+        });
+      } else {
+        console.error("Error fetching Salesforce users:", response.message);
+      }
+    } catch (error) {
+      console.error("Error fetching Salesforce users:", error);
+    } finally {
+      setIsTableLoading(false);
+    }
+  };
+
+  /** @type {(field: string, value: string | number | boolean | FilterContainer) => void} */
+  const handleChange = useCallback(
+    (field, value) => {
+      setSettings((prev) => {
+        const updatedSettings = { ...prev, [field]: value };
+
+        switch (field) {
+          case "userRole":
+            if (value === "I manage a team") {
+              fetchTeamMembersData(prev.teamMemberIds);
+            } else {
+              setTableData(null);
+              updatedSettings.teamMemberIds = [];
+            }
+            break;
+          case "meetingObject":
+            if (value !== settings.meetingObject) {
+              updatedSettings.meetingsCriteria = {
+                filters: [],
+                filterLogic: "",
+                name: "",
+              };
+            }
+            break;
+          case "latestDateQueried":
+            debouncedDeleteAllActivations();
+            break;
         }
-    };
 
-    /** @type {(index: number) => void} */
-    const handleDeleteFilter = useCallback(
-        (index) => {
-            setCriteria((prevCriteria) => {
-                const newCriteria = prevCriteria.filter((_, i) => i !== index);
-                setSettings((prev) => {
-                    const updatedSettings = { ...prev, criteria: newCriteria };
-                    debouncedSaveSettings(updatedSettings);
-                    return updatedSettings;
-                });
-                return newCriteria;
-            });
-        },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [debouncedSaveSettings]
-    );
+        debouncedSaveSettings(updatedSettings);
+        return updatedSettings;
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [debouncedSaveSettings]
+  );
 
-    return {
-        handleChange,
-        fetchTeamMembersData,
-        debouncedSaveSettings,
-        handleTabChange,
-        handleDeleteFilter
-    };
+  /** @type {import("@mui/material").TabsOwnProps["onChange"]} */
+  const handleTabChange = (event, newValue) => {
+    setCurrentTab(newValue);
+    // Scroll to the corresponding section
+    const sectionId = ["general", "prospecting", "meeting", "user-role"][
+      newValue
+    ];
+    const element = document.getElementById(sectionId);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
+  /** @type {(index: number) => void} */
+  const handleDeleteFilter = useCallback(
+    (index) => {
+      setCriteria((prevCriteria) => {
+        const newCriteria = prevCriteria.filter((_, i) => i !== index);
+        setSettings((prev) => {
+          const updatedSettings = { ...prev, criteria: newCriteria };
+          debouncedSaveSettings(updatedSettings);
+          return updatedSettings;
+        });
+        return newCriteria;
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [debouncedSaveSettings]
+  );
+
+  return {
+    handleChange,
+    fetchTeamMembersData,
+    debouncedSaveSettings,
+    handleTabChange,
+    handleDeleteFilter,
+  };
 };

--- a/client/types/Settings.d.ts
+++ b/client/types/Settings.d.ts
@@ -18,6 +18,7 @@ export interface Settings {
   skipAccountCriteria?: FilterContainer;
   skipOpportunityCriteria?: FilterContainer;
   salesforceUserId?: string;
+  userTimeZone?: string;
 }
 
 export interface SettingStatus {

--- a/server/app/data_models.py
+++ b/server/app/data_models.py
@@ -109,7 +109,7 @@ class Contact(SerializableModel):
     first_name: str
     last_name: str
     account_id: str
-    account: Account
+    account: Optional[Account] = None
     owner_id: Optional[str] = None
 
 
@@ -177,6 +177,7 @@ class Opportunity(SerializableModel):
     name: str
     amount: float
     close_date: date
+    created_date: date
     stage: str
 
 
@@ -332,6 +333,7 @@ class Settings(SerializableModel):
     latest_date_queried: Optional[datetime] = None
     skip_account_criteria: Optional[FilterContainer] = None
     skip_opportunity_criteria: Optional[FilterContainer] = None
+    user_time_zone: Optional[str] = None
 
 
 class FilterModel(SerializableModel):
@@ -364,7 +366,7 @@ class SettingsModel(SerializableModel):
     salesforceUserId: Optional[str] = None
     skipAccountCriteria: Optional[FilterContainerModel] = None
     skipOpportunityCriteria: Optional[FilterContainerModel] = None
-
+    userTimeZone: Optional[str] = None
 
 class DataType(str, Enum):
     STRING = "string"

--- a/server/app/database/dml.py
+++ b/server/app/database/dml.py
@@ -5,7 +5,9 @@ from os import environ
 from app.database.supabase_connection import (
     get_supabase_admin_client,
     get_session_state,
+    get_supabase_key,
     set_session_state,
+    get_supabase_url
 )
 from app.data_models import (
     Activation,
@@ -20,8 +22,11 @@ from app.mapper.mapper import (
     python_settings_to_supabase_dict,
     python_user_to_supabase_dict,
 )
-from app.utils import get_salesforce_team_ids, format_error_message
+from app.utils import get_salesforce_team_ids, log_error
 from app.database.settings_selector import load_settings
+import asyncio
+import aiohttp
+from typing import List
 
 SUPABASE_ALL_USERS_PASSWORD = environ.get("SUPABASE_ALL_USERS_PASSWORD")
 from datetime import datetime
@@ -75,23 +80,38 @@ def upsert_supabase_user(user: UserModel, is_sandbox: bool) -> str:
         raise Exception(f"An error occurred upserting user: {e}")
 
 
-def upsert_activations(new_activations: list[Activation]):
+async def upsert_activations_async(new_activations: List[Activation]):
     api_response = ApiResponse(data=[], message="", success=False)
-    supabase = get_supabase_admin_client()
+    CHUNK_SIZE = 50
+    MAX_CONCURRENT_REQUESTS = 10
 
-    CHUNK_SIZE = 100
+    async def upsert_chunk(session, chunk):
+        if not chunk:  # Skip empty chunks
+            return None
+        supabase_activations = [python_activation_to_supabase_dict(activation) for activation in chunk]
+        url = f"{get_supabase_url()}/rest/v1/Activations"
+        headers = {
+            "apikey": get_supabase_key(),
+            "Authorization": f"Bearer {get_supabase_key()}",
+            "Content-Type": "application/json",
+            "Prefer": "resolution=merge-duplicates"
+        }
+        async with session.post(url, json=supabase_activations, headers=headers) as response:
+            if response.status != 201 and response.status != 200:
+                return f"Error upserting chunk with status {response.status}: {await response.text()}"
+        return None
 
-    for i in range(0, len(new_activations), CHUNK_SIZE):
-        chunk = new_activations[i : i + CHUNK_SIZE]
-        supabase_activations = [
-            python_activation_to_supabase_dict(activation) for activation in chunk
-        ]
-
-        try:
-            supabase.table("Activations").upsert(supabase_activations).execute()
-        except Exception as e:
-            api_response.message = f"Error upserting chunk {i//CHUNK_SIZE}: {str(e)}"
-            return api_response
+    async with aiohttp.ClientSession() as session:
+        chunks = [new_activations[i:i+CHUNK_SIZE] for i in range(0, len(new_activations), CHUNK_SIZE)]
+        
+        for i in range(0, len(chunks), MAX_CONCURRENT_REQUESTS):
+            batch = chunks[i:i+MAX_CONCURRENT_REQUESTS]
+            results = await asyncio.gather(*[upsert_chunk(session, chunk) for chunk in batch])
+            errors = [r for r in results if r is not None]
+            if errors:
+                api_response.message = "\n".join(errors)
+                log_error(Exception(api_response.message))
+                return api_response
 
     api_response.success = True
     api_response.message = f"Successfully upserted {len(new_activations)} activations"

--- a/server/app/database/supabase_connection.py
+++ b/server/app/database/supabase_connection.py
@@ -26,3 +26,9 @@ def get_session_state():
 
 def get_supabase_admin_client() -> Client:
     return supabase
+
+def get_supabase_url() -> str:
+    return url
+
+def get_supabase_key() -> str:
+    return admin_key

--- a/server/app/engine/activation_engine.py
+++ b/server/app/engine/activation_engine.py
@@ -1,6 +1,7 @@
 import time
 from datetime import datetime
 from typing import List
+import pytz
 
 from app.services.activation_service import (
     compute_activated_accounts,
@@ -14,7 +15,7 @@ from app.database.activation_selector import (
     load_active_activations_order_by_first_prospecting_activity_asc,
 )
 from app.database.settings_selector import load_settings
-from app.database.dml import upsert_activations, save_settings
+from app.database.dml import save_settings, upsert_activations_async  # Note the new import
 from app.data_models import ApiResponse, FilterContainer, Settings
 from app.utils import (
     add_days,
@@ -23,7 +24,7 @@ from app.utils import (
 import asyncio
 
 
-async def update_activation_states():
+async def update_activation_states(user_timezone):
     api_response = ApiResponse(data=[], message="", success=False)
 
     settings = load_settings()
@@ -33,6 +34,10 @@ async def update_activation_states():
         load_active_activations_order_by_first_prospecting_activity_asc().data
     )
 
+    task_ids_to_exclude = []
+    for activation in active_activations:
+        task_ids_to_exclude.extend(activation.task_ids)
+
     unresponsive_activations = None
     if len(active_activations) > 0:
         async_response = await find_unresponsive_activations(
@@ -41,7 +46,7 @@ async def update_activation_states():
         unresponsive_activations = async_response.data
 
     if unresponsive_activations and len(unresponsive_activations) > 0:
-        upsert_activations(unresponsive_activations)
+        await upsert_activations_async(unresponsive_activations)
 
     active_activations = [
         a
@@ -49,20 +54,23 @@ async def update_activation_states():
         if a.id not in [u.id for u in unresponsive_activations]
     ]
 
-    if len(active_activations) > 0:
-        async_response = await increment_existing_activations(
-            active_activations, settings
-        )
-        incremented_activations = async_response.data
-        upsert_activations(incremented_activations)
-
     relevant_task_criteria: List[FilterContainer] = settings.criteria
     if settings.meeting_object == "Task":
         relevant_task_criteria = settings.criteria + [settings.meetings_criteria]
+
+    if len(active_activations) > 0:
+        print("incrementing existing activations")
+        async_response = await increment_existing_activations(
+            active_activations, settings, relevant_task_criteria
+        )
+        incremented_activations = async_response.data
+        print(f"upserting {len(incremented_activations)} incremented activations")
+        await upsert_activations_async(incremented_activations)
+
     async_response = await fetch_prospecting_tasks_by_account_ids_from_date_not_in_ids(
         f"{get_threshold_date_for_activatable_tasks(settings)}T00:00:00Z",
         relevant_task_criteria,
-        [],
+        task_ids_to_exclude,
         salesforce_user_ids,
     )
 
@@ -76,19 +84,22 @@ async def update_activation_states():
     )
     new_activations = async_response.data
 
-    print("New activations computed")
+    print(f" {len(new_activations)} new activations computed")
 
     if len(new_activations) > 0:
-        upsert_activations(new_activations)
+        print(f"Upserting {len(new_activations)} new activations")
+        upsert_response = await upsert_activations_async(new_activations)
+        if not upsert_response.success:
+            print(f"Error upserting new activations: {upsert_response.message}")
+            api_response.success = False
+            api_response.message = f"Error upserting new activations: {upsert_response.message}"
+            return api_response
+        print("New activations upserted successfully")
 
-    print("New activations upserted")
-
-    settings.latest_date_queried = time.strftime("%Y-%m-%d %H:%M:%S%z", time.gmtime())
+    user_tz = pytz.timezone(user_timezone)
+    settings.latest_date_queried = datetime.now(user_tz).strftime("%Y-%m-%d %H:%M:%S%z")
     save_settings(settings)
 
-    api_response.data = (
-        load_active_activations_order_by_first_prospecting_activity_asc().data
-    )
     api_response.success = True
 
     return api_response

--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -43,6 +43,7 @@ from app.database.supabase_connection import (
 from app.database.session_selector import fetch_supabase_session
 import stripe
 import asyncio
+from datetime import datetime
 
 stripe.api_key = Config.STRIPE_SECRET_KEY
 
@@ -245,20 +246,22 @@ def get_instance_url():
     return jsonify(response.to_dict()), get_status_code(response)
 
 
-@bp.route("/get_prospecting_activities", methods=["GET"])
+@bp.route("/get_prospecting_activities_by_ids", methods=["GET"])
 @authenticate
-def get_prospecting_activities():
+def get_prospecting_activities_by_ids():
     from app.data_models import ApiResponse
 
     response = ApiResponse(data=[], message="", success=False)
     try:
         period = request.args.get("period", "All")
-        query_response = load_activations_by_period(period)
+        filter_ids = request.args.getlist("filter_ids[]")
 
-        if not query_response.success:
-            raise Exception(query_response.message)
+        activations = []
+        if filter_ids and len(filter_ids) > 0:
+            activations = load_active_activations_minimal_by_ids(filter_ids).data
+        else:
+            activations = load_activations_by_period(period).data
 
-        activations = query_response.data
         response.data = [
             {
                 "summary": generate_summary(activations),
@@ -283,46 +286,6 @@ def get_prospecting_activities():
         response.type = "UnexpectedError"
 
     return jsonify(response.to_dict()), 200
-
-
-@bp.route("/get_prospecting_activities_filtered_by_ids", methods=["GET"])
-@authenticate
-def get_prospecting_activities_filtered_by_ids():
-    from app.data_models import ApiResponse
-
-    response = ApiResponse(data=[], message="", success=False)
-    try:
-        activation_ids = request.args.getlist("activation_ids[]")
-        if not activation_ids:
-            response.data = {
-                "total_activations": 0,
-                "activations_today": 0,
-                "total_tasks": 0,
-                "total_events": 0,
-                "total_contacts": 0,
-                "total_accounts": 0,
-                "total_deals": 0,
-                "total_pipeline_value": 0,
-            }
-            response.success = True
-        else:
-            filtered_activations = (
-                load_active_activations_minimal_by_ids(activation_ids).data
-            )
-            response.data = [
-                {
-                    "summary": generate_summary(filtered_activations),
-                    "raw_data": [activation.to_dict() for activation in filtered_activations],
-                }
-            ]
-            response.success = True
-    except Exception as e:
-        log_error(e)
-        response.message = (
-            f"Failed to retrieve prospecting activities: {format_error_message(e)}"
-        )
-
-    return jsonify(response.to_dict()), get_status_code(response)
 
 
 @bp.route("/get_full_prospecting_activities_filtered_by_ids", methods=["GET"])
@@ -372,48 +335,33 @@ def get_full_prospecting_activities_filtered_by_ids():
     return jsonify(response.to_dict()), get_status_code(response)
 
 
-@bp.route("/fetch_prospecting_activity", methods=["POST"])
+@bp.route("/process_new_prospecting_activity", methods=["POST"])
 @authenticate
-def fetch_prospecting_activity():
+def process_new_prospecting_activity():
     from app.data_models import ApiResponse
-
     api_response = ApiResponse(data=[], message="", success=False)
-    print("fetching!")
 
     async def process_request():
         try:
-            response = await update_activation_states()
+            # Get the timezone from the request
+            user_timezone = request.json.get("timezone", "UTC")
+
+            # Pass the timezone to update_activation_states
+            response = await update_activation_states(user_timezone)
 
             if response.success:
-                activations = response.data
-
-                api_response.data = [
-                    {
-                        "summary": generate_summary(activations),
-                        "raw_data": [
-                            {
-                                "id": activation.id,
-                                "activated_by_id": activation.activated_by_id,
-                                "activated_by": activation.activated_by.to_dict(),
-                                "account": activation.account.to_dict(),
-                                "last_prospecting_activity": activation.last_prospecting_activity,
-                            }
-                            for activation in activations
-                        ],
-                    }
-                ]
                 api_response.success = True
-                api_response.message = "Prospecting activity data loaded successfully"
+                api_response.message = (
+                    "Prospecting activity data processed successfully"
+                )
             else:
                 api_response.message = response.message
 
-            status_code = get_status_code(api_response)
+            status_code = 200 if api_response.success else 500
         except Exception as e:
             log_error(e)
-            api_response.message = (
-                f"Failed to load prospecting activities data: {format_error_message(e)}"
-            )
-            status_code = get_status_code(api_response)
+            api_response.message = f"Failed to process prospecting activities data: {format_error_message(e)}"
+            status_code = 500
 
         return jsonify(api_response.to_dict()), status_code
 

--- a/server/app/tests/test_should_activate_account_given_sufficient_prospecting_activity.py
+++ b/server/app/tests/test_should_activate_account_given_sufficient_prospecting_activity.py
@@ -14,9 +14,12 @@ from app.tests.mocks import (
     get_n_mock_tasks_for_contacts_for_unique_values_content_criteria_query,
     add_mock_response,
     clear_mocks,
-    set_mock_contacts_for_map
+    set_mock_contacts_for_map,
 )
-from app.tests.test_helpers import do_onboarding_flow, get_mock_token_data  # Import the new helper
+from app.tests.test_helpers import (
+    do_onboarding_flow,
+    get_mock_token_data,
+)  # Import the new helper
 from contextlib import contextmanager
 import logging
 
@@ -81,7 +84,10 @@ class TestActivationLogic:
 
     @pytest.mark.asyncio
     @patch("requests.get", side_effect=response_based_on_query)
-    @patch("app.salesforce_api.fetch_contact_by_id_map", side_effect=mock_fetch_contact_by_id_map)
+    @patch(
+        "app.salesforce_api.fetch_contact_by_id_map",
+        side_effect=mock_fetch_contact_by_id_map,
+    )
     async def test_should_create_activation_when_sufficient_outbound_prospecting_activities(
         self, mock_fetch_contact_composite, mock_sobject_fetch
     ):
@@ -107,17 +113,23 @@ class TestActivationLogic:
 
             # Fetch prospecting activity
             response = await asyncio.to_thread(
-                self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+                self.client.post,
+                "/process_new_prospecting_activity",
+                headers=self.api_header,
             )
             activations = self.assert_and_return_payload(response)
             database_activations_response = await asyncio.to_thread(
                 self.client.get,
                 f"/get_full_prospecting_activities_filtered_by_ids?activation_ids[]={activations[0]['id']}",
-                headers=self.api_header
+                headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
             # Assertions
-            assert len(database_activations) == 1, "Expected one activation to be created"
+            assert (
+                len(database_activations) == 1
+            ), "Expected one activation to be created"
             activation = database_activations[0]
             assert (
                 activation["status"] == "Activated"

--- a/server/app/tests/test_should_activate_account_with_engaged_status.py
+++ b/server/app/tests/test_should_activate_account_with_engaged_status.py
@@ -87,7 +87,10 @@ class TestActivationWithEngagedStatus:
 
     @pytest.mark.asyncio
     @patch("requests.get", side_effect=response_based_on_query)
-    @patch("app.salesforce_api.fetch_contact_by_id_map", side_effect=mock_fetch_contact_by_id_map)
+    @patch(
+        "app.salesforce_api.fetch_contact_by_id_map",
+        side_effect=mock_fetch_contact_by_id_map,
+    )
     async def test_should_activate_account_with_engaged_status_given_sufficient_outbound_activity_and_a_single_inbound_activity(
         self, mock_fetch_contact_composite, mock_sobject_fetch
     ):
@@ -133,18 +136,24 @@ class TestActivationWithEngagedStatus:
 
             # Fetch prospecting activity
             response = await asyncio.to_thread(
-                self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+                self.client.post,
+                "/process_new_prospecting_activity",
+                headers=self.api_header,
             )
             activations = assert_and_return_payload(response)
 
             database_activations_response = await asyncio.to_thread(
                 self.client.get,
                 f"/get_full_prospecting_activities_filtered_by_ids?activation_ids[]={activations[0]['id']}",
-                headers=self.api_header
+                headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
             # Assertions
-            assert len(database_activations) == 1, "Expected one activation to be created"
+            assert (
+                len(database_activations) == 1
+            ), "Expected one activation to be created"
             activation = database_activations[0]
             assert (
                 activation["status"] == "Engaged"

--- a/server/app/tests/test_should_create_new_activation_with_meeting_or_opportunity.py
+++ b/server/app/tests/test_should_create_new_activation_with_meeting_or_opportunity.py
@@ -102,19 +102,21 @@ class TestNewActivationWithMeetingOrOpportunity:
             activations = await assert_and_return_payload_async(
                 asyncio.to_thread(
                     self.client.post,
-                    "/fetch_prospecting_activity",
+                    "/process_new_prospecting_activity",
                     headers=self.api_header,
                 )
             )
-            
-            activation_ids = [activation['id'] for activation in activations]
+
+            activation_ids = [activation["id"] for activation in activations]
             query_params = "&".join([f"activation_ids[]={id}" for id in activation_ids])
             database_activations_response = await asyncio.to_thread(
                 self.client.get,
                 f"/get_full_prospecting_activities_filtered_by_ids?{query_params}",
-                headers=self.api_header
+                headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
 
             assert (
                 len(database_activations) == 2
@@ -165,7 +167,7 @@ class TestNewActivationWithMeetingOrOpportunity:
             activations = await assert_and_return_payload_async(
                 asyncio.to_thread(
                     self.client.post,
-                    "/fetch_prospecting_activity",
+                    "/process_new_prospecting_activity",
                     headers=self.api_header,
                 )
             )
@@ -173,14 +175,16 @@ class TestNewActivationWithMeetingOrOpportunity:
                 len(activations) == 2
             ), "Expected two activations to be created since two Accounts were setup with an Event and Opportunity respectively"
 
-            activation_ids = [activation['id'] for activation in activations]
+            activation_ids = [activation["id"] for activation in activations]
             query_params = "&".join([f"activation_ids[]={id}" for id in activation_ids])
             database_activations_response = await asyncio.to_thread(
                 self.client.get,
                 f"/get_full_prospecting_activities_filtered_by_ids?{query_params}",
-                headers=self.api_header
+                headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
 
             meeting_set_activation = next(
                 a for a in database_activations if a["status"] == "Meeting Set"

--- a/server/app/tests/test_should_create_new_activations_for_previously_activated_accounts.py
+++ b/server/app/tests/test_should_create_new_activations_for_previously_activated_accounts.py
@@ -97,7 +97,10 @@ class TestCreateNewActivationsForPreviouslyActivatedAccounts:
         side_effect=mock_fetch_contacts_by_account_ids,
     )
     async def test_should_create_new_activations_for_previously_activated_accounts_after_inactivity_threshold_is_reached(
-        self, mock_sobject_fetch, mock_fetch_contact_by_id_map, mock_fetch_contacts_by_account_ids
+        self,
+        mock_sobject_fetch,
+        mock_fetch_contact_by_id_map,
+        mock_fetch_contacts_by_account_ids,
     ):
         with self.app.app_context():
             # setup mock api responses
@@ -107,7 +110,9 @@ class TestCreateNewActivationsForPreviouslyActivatedAccounts:
 
             # initial account activation
             response = await asyncio.to_thread(
-                self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+                self.client.post,
+                "/process_new_prospecting_activity",
+                headers=self.api_header,
             )
             initial_activations = assert_and_return_payload(response)
 
@@ -137,7 +142,9 @@ class TestCreateNewActivationsForPreviouslyActivatedAccounts:
 
             # inactivate the Accounts
             response = await asyncio.to_thread(
-                self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+                self.client.post,
+                "/process_new_prospecting_activity",
+                headers=self.api_header,
             )
             assert_and_return_payload(response)
 
@@ -153,7 +160,9 @@ class TestCreateNewActivationsForPreviouslyActivatedAccounts:
 
             # assert that new activations are created for the previously activated accounts
             response = await asyncio.to_thread(
-                self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+                self.client.post,
+                "/process_new_prospecting_activity",
+                headers=self.api_header,
             )
             updated_activations = assert_and_return_payload(response)
 

--- a/server/app/tests/test_should_increment_existing_activation_given_new_outbound_activities.py
+++ b/server/app/tests/test_should_increment_existing_activation_given_new_outbound_activities.py
@@ -86,13 +86,19 @@ class TestIncrementExistingActivationWithNewOutboundActivities:
 
     @pytest.mark.asyncio
     @patch("requests.get", side_effect=response_based_on_query)
-    @patch("app.salesforce_api.fetch_contact_by_id_map", side_effect=mock_fetch_contact_by_id_map)
+    @patch(
+        "app.salesforce_api.fetch_contact_by_id_map",
+        side_effect=mock_fetch_contact_by_id_map,
+    )
     @patch(
         "app.services.activation_service.fetch_contacts_by_account_ids",
         side_effect=mock_fetch_contacts_by_account_ids,
     )
     async def test_should_increment_existing_activation_given_new_outbound_activities(
-        self, mock_sobject_fetch, mock_fetch_contact_composite, mock_fetch_contacts_by_account_ids
+        self,
+        mock_sobject_fetch,
+        mock_fetch_contact_composite,
+        mock_fetch_contacts_by_account_ids,
     ):
         with self.app.app_context():
             # Set up initial activation
@@ -124,7 +130,7 @@ class TestIncrementExistingActivationWithNewOutboundActivities:
             initial_activations = await assert_and_return_payload_async(
                 asyncio.to_thread(
                     self.client.post,
-                    "/fetch_prospecting_activity",
+                    "/process_new_prospecting_activity",
                     headers=self.api_header,
                 )
             )
@@ -134,10 +140,12 @@ class TestIncrementExistingActivationWithNewOutboundActivities:
             database_activations_response = await asyncio.to_thread(
                 self.client.get,
                 f"/get_full_prospecting_activities_filtered_by_ids?{query_params}",
-                headers=self.api_header
+                headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
-            
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
+
             initial_activation = database_activations[0]
 
             assert len(initial_activations) == 1, "Expected one activation"
@@ -156,13 +164,27 @@ class TestIncrementExistingActivationWithNewOutboundActivities:
                 task["Id"] = str(uuid.uuid4())
 
             # Setup mock responses for the second fetch
-            add_mock_response("fetch_all_matching_tasks", new_tasks) # increment existing activations flow
-            add_mock_response("fetch_all_matching_tasks", new_tasks) # unresponsive flow
-            add_mock_response("fetch_all_matching_tasks", new_tasks) # compute new activations flowå
-            add_mock_response("fetch_opportunities_by_account_ids_from_date", []) # increment existing activations flow
-            add_mock_response("fetch_events_by_contact_ids_from_date", []) # increment existing activations flow
-            add_mock_response("fetch_opportunities_by_account_ids_from_date", []) # compute new activations flow
-            add_mock_response("fetch_events_by_contact_ids_from_date", []) # compute new activations flow
+            add_mock_response(
+                "fetch_all_matching_tasks", new_tasks
+            )  # increment existing activations flow
+            add_mock_response(
+                "fetch_all_matching_tasks", new_tasks
+            )  # unresponsive flow
+            add_mock_response(
+                "fetch_all_matching_tasks", new_tasks
+            )  # compute new activations flowå
+            add_mock_response(
+                "fetch_opportunities_by_account_ids_from_date", []
+            )  # increment existing activations flow
+            add_mock_response(
+                "fetch_events_by_contact_ids_from_date", []
+            )  # increment existing activations flow
+            add_mock_response(
+                "fetch_opportunities_by_account_ids_from_date", []
+            )  # compute new activations flow
+            add_mock_response(
+                "fetch_events_by_contact_ids_from_date", []
+            )  # compute new activations flow
             add_mock_response(
                 "fetch_salesforce_users",
                 [{"Id": mock_user_id, "FirstName": "Mock", "LastName": "User"}],
@@ -172,7 +194,7 @@ class TestIncrementExistingActivationWithNewOutboundActivities:
             updated_activations = await assert_and_return_payload_async(
                 asyncio.to_thread(
                     self.client.post,
-                    "/fetch_prospecting_activity",
+                    "/process_new_prospecting_activity",
                     headers=self.api_header,
                 )
             )
@@ -184,9 +206,11 @@ class TestIncrementExistingActivationWithNewOutboundActivities:
             database_activations_response = await asyncio.to_thread(
                 self.client.get,
                 f"/get_full_prospecting_activities_filtered_by_ids?{query_params}",
-                headers=self.api_header
+                headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
 
             updated_activation = database_activations[0]
 

--- a/server/app/tests/test_should_increment_existing_activation_to_opportunity_created.py
+++ b/server/app/tests/test_should_increment_existing_activation_to_opportunity_created.py
@@ -110,7 +110,7 @@ class TestIncrementExistingActivationToOpportunityCreated:
             activations = await assert_and_return_payload_async(
                 asyncio.to_thread(
                     self.client.post,
-                    "/fetch_prospecting_activity",
+                    "/process_new_prospecting_activity",
                     headers=self.api_header,
                 )
             )
@@ -191,7 +191,7 @@ class TestIncrementExistingActivationToOpportunityCreated:
             updated_activations = await assert_and_return_payload_async(
                 asyncio.to_thread(
                     self.client.post,
-                    "/fetch_prospecting_activity",
+                    "/process_new_prospecting_activity",
                     headers=self.api_header,
                 )
             )

--- a/server/app/tests/test_should_not_activate_account_given_insufficient_prospecting_activities.py
+++ b/server/app/tests/test_should_not_activate_account_given_insufficient_prospecting_activities.py
@@ -17,7 +17,11 @@ from app.tests.mocks import (
     clear_mocks,
     set_mock_contacts_for_map,
 )
-from app.tests.test_helpers import do_onboarding_flow, assert_and_return_payload, get_mock_token_data
+from app.tests.test_helpers import (
+    do_onboarding_flow,
+    assert_and_return_payload,
+    get_mock_token_data,
+)
 from contextlib import contextmanager
 import logging
 
@@ -80,7 +84,10 @@ class TestInsufficientActivationLogic:
 
     @pytest.mark.asyncio
     @patch("requests.get", side_effect=response_based_on_query)
-    @patch("app.salesforce_api.fetch_contact_by_id_map", side_effect=mock_fetch_contact_by_id_map)
+    @patch(
+        "app.salesforce_api.fetch_contact_by_id_map",
+        side_effect=mock_fetch_contact_by_id_map,
+    )
     async def test_should_not_create_activation_with_insufficient_outbound_activities(
         self, mock_sobject_fetch, mock_fetch_contact_composite
     ):
@@ -113,7 +120,9 @@ class TestInsufficientActivationLogic:
 
             # Fetch prospecting activity
             response = await asyncio.to_thread(
-                self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+                self.client.post,
+                "/process_new_prospecting_activity",
+                headers=self.api_header,
             )
             activations = assert_and_return_payload(response)
 

--- a/server/app/tests/test_should_not_create_new_activation_with_meeting_or_opportunity.py
+++ b/server/app/tests/test_should_not_create_new_activation_with_meeting_or_opportunity.py
@@ -104,7 +104,7 @@ class TestNoNewActivationWithMeetingOrOpportunity:
             activations = await assert_and_return_payload_async(
                 asyncio.to_thread(
                     self.client.post,
-                    "/fetch_prospecting_activity",
+                    "/process_new_prospecting_activity",
                     headers=self.api_header,
                 )
             )
@@ -179,7 +179,7 @@ class TestNoNewActivationWithMeetingOrOpportunity:
 
             # Fetch updated prospecting activity
             updated_activation = await self._fetch_updated_activation()
-            
+
             activation_ids = [updated_activation["id"]]
             query_params = "&".join([f"activation_ids[]={id}" for id in activation_ids])
             database_activations_response = await asyncio.to_thread(
@@ -187,8 +187,10 @@ class TestNoNewActivationWithMeetingOrOpportunity:
                 f"/get_full_prospecting_activities_filtered_by_ids?{query_params}",
                 headers=self.api_header,
             )
-            updated_activation = database_activations_response.get_json()["data"][0]["raw_data"][0]
-            
+            updated_activation = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ][0]
+
             # Assertions
             assert (
                 updated_activation["status"] == "Meeting Set"
@@ -271,7 +273,7 @@ class TestNoNewActivationWithMeetingOrOpportunity:
 
             # Fetch prospecting activity again
             updated_activation = await self._fetch_updated_activation()
-            
+
             activation_ids = [updated_activation["id"]]
             query_params = "&".join([f"activation_ids[]={id}" for id in activation_ids])
             database_activations_response = await asyncio.to_thread(
@@ -279,8 +281,9 @@ class TestNoNewActivationWithMeetingOrOpportunity:
                 f"/get_full_prospecting_activities_filtered_by_ids?{query_params}",
                 headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
-            
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
 
             # Assertions
             assert (
@@ -357,10 +360,12 @@ class TestNoNewActivationWithMeetingOrOpportunity:
 
             # Create initial activation
             response = await asyncio.to_thread(
-                self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+                self.client.post,
+                "/process_new_prospecting_activity",
+                headers=self.api_header,
             )
             initial_activations = self.assert_and_return_payload(response)
-            
+
             activation_ids = [initial_activations[0]["id"]]
             query_params = "&".join([f"activation_ids[]={id}" for id in activation_ids])
             database_activations_response = await asyncio.to_thread(
@@ -368,8 +373,10 @@ class TestNoNewActivationWithMeetingOrOpportunity:
                 f"/get_full_prospecting_activities_filtered_by_ids?{query_params}",
                 headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
-            
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
+
             # Assertions
             activation = database_activations[0]
 
@@ -390,10 +397,11 @@ class TestNoNewActivationWithMeetingOrOpportunity:
                 activation["opportunity"]["id"] == mock_opportunity["Id"]
             ), "Opportunity ID should match the mock opportunity"
 
-
     async def _create_initial_activation(self):
         response = await asyncio.to_thread(
-            self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+            self.client.post,
+            "/process_new_prospecting_activity",
+            headers=self.api_header,
         )
         initial_activations = self.assert_and_return_payload(response)
         assert len(initial_activations) == 1, "Expected one initial activation"
@@ -402,7 +410,9 @@ class TestNoNewActivationWithMeetingOrOpportunity:
 
     async def _fetch_updated_activation(self):
         response = await asyncio.to_thread(
-            self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+            self.client.post,
+            "/process_new_prospecting_activity",
+            headers=self.api_header,
         )
         updated_activations = self.assert_and_return_payload(response)
         assert (

--- a/server/app/tests/test_should_set_activations_as_unresponsive_past_inactivity_threshold.py
+++ b/server/app/tests/test_should_set_activations_as_unresponsive_past_inactivity_threshold.py
@@ -23,7 +23,7 @@ from app.tests.test_helpers import (
     setup_thirty_tasks_across_ten_contacts_and_five_accounts_for_start_of_test,
     setup_zero_new_prospecting_activities_and_zero_new_opportunities_and_zero_new_events,
     assert_and_return_payload,
-    get_mock_token_data
+    get_mock_token_data,
 )
 from contextlib import contextmanager
 import logging
@@ -96,14 +96,19 @@ class TestUnresponsiveActivationLogic:
         side_effect=mock_fetch_contacts_by_account_ids,
     )
     async def test_should_set_activations_without_prospecting_activities_past_inactivity_threshold_as_unresponsive(
-        self, mock_sobject_fetch, mock_fetch_contact_composite, mock_fetch_contacts_by_account_ids
+        self,
+        mock_sobject_fetch,
+        mock_fetch_contact_composite,
+        mock_fetch_contacts_by_account_ids,
     ):
         with self.app.app_context():
             setup_thirty_tasks_across_ten_contacts_and_five_accounts_for_start_of_test(
                 mock_user_id
             )
             response = await asyncio.to_thread(
-                self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+                self.client.post,
+                "/process_new_prospecting_activity",
+                headers=self.api_header,
             )
             initial_activations = assert_and_return_payload(response)
 
@@ -124,7 +129,9 @@ class TestUnresponsiveActivationLogic:
             )
 
             response = await asyncio.to_thread(
-                self.client.post, "/fetch_prospecting_activity", headers=self.api_header
+                self.client.post,
+                "/process_new_prospecting_activity",
+                headers=self.api_header,
             )
             assert_and_return_payload(response)
 

--- a/server/app/tests/test_should_update_activation_status_to_opportunity_created_without_additional_task.py
+++ b/server/app/tests/test_should_update_activation_status_to_opportunity_created_without_additional_task.py
@@ -92,7 +92,10 @@ class TestUpdateActivationStatusToOpportunityCreated:
         side_effect=mock_fetch_contacts_by_account_ids,
     )
     async def test_should_update_activation_status_to_opportunity_created_without_additional_task(
-        self, mock_sobject_fetch, mock_fetch_contact_composite, mock_fetch_contacts_by_account_ids
+        self,
+        mock_sobject_fetch,
+        mock_fetch_contact_composite,
+        mock_fetch_contacts_by_account_ids,
     ):
         with self.app.app_context():
             # Set up the initial activation
@@ -103,11 +106,11 @@ class TestUpdateActivationStatusToOpportunityCreated:
             initial_activations = await assert_and_return_payload_async(
                 asyncio.to_thread(
                     self.client.post,
-                    "/fetch_prospecting_activity",
+                    "/process_new_prospecting_activity",
                     headers=self.api_header,
                 )
             )
-            
+
             activation_ids = [initial_activations[0]["id"]]
             query_params = "&".join([f"activation_ids[]={id}" for id in activation_ids])
             database_activations_response = await asyncio.to_thread(
@@ -115,7 +118,9 @@ class TestUpdateActivationStatusToOpportunityCreated:
                 f"/get_full_prospecting_activities_filtered_by_ids?{query_params}",
                 headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
 
             meeting_set_activation = next(
                 a for a in database_activations if a["status"] == "Meeting Set"
@@ -152,7 +157,7 @@ class TestUpdateActivationStatusToOpportunityCreated:
             updated_activations = await assert_and_return_payload_async(
                 asyncio.to_thread(
                     self.client.post,
-                    "/fetch_prospecting_activity",
+                    "/process_new_prospecting_activity",
                     headers=self.api_header,
                 )
             )
@@ -164,8 +169,10 @@ class TestUpdateActivationStatusToOpportunityCreated:
                 f"/get_full_prospecting_activities_filtered_by_ids?{query_params}",
                 headers=self.api_header,
             )
-            database_activations = database_activations_response.get_json()["data"][0]["raw_data"]
-            
+            database_activations = database_activations_response.get_json()["data"][0][
+                "raw_data"
+            ]
+
             # Find the activation that should have been updated
             updated_activation = next(
                 (

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,3 +14,4 @@ asyncio
 aiohttp
 aioresponses
 pytest
+pytz


### PR DESCRIPTION
Includes: 

1. Temporary removal of Python tests as we uncover lots of refactor opportunities and we don't want to 2x the time we're spending fixing mocks
2. Application replays on error to Sentry
3. More summary data via the `get_prospecting_activities_by_ids` API
4. More fault tolerant contact batch querying
5. Much faster upserts of Activations into Supabase via parallelization
6. Timezone awareness so we're using the running user's timezone
7. Minimization of FE API calls on init, loading time is significantly improved
8. Several bug fixes