### PR TITLE
hotfix-query-all-users-included-in-team-member-ids

### DIFF
--- a/scripts/ngrok/ngrok.yml
+++ b/scripts/ngrok/ngrok.yml
@@ -3,8 +3,10 @@ tunnels:
   webapp1:
     proto: http
     addr: 3000
+    inspect: false
   webapp2:
     proto: http
     addr: 8000
     hostname: strongly-talented-troll.ngrok-free.app
+    inspect: false
 authtoken: 1aQHhya3sSfB001TmtG66cQSN6K_4ahpmL9A719aV8TiSPkn9

--- a/server/app/salesforce_api.py
+++ b/server/app/salesforce_api.py
@@ -82,7 +82,7 @@ def fetch_salesforce_users(ids: list[str] = None) -> ApiResponse:
         soql_query = "SELECT Id,Email,FirstName,LastName,Username,FullPhotoUrl,UserRole.Name FROM User"
 
         if ids:
-            soql_query += " AND Id IN ({})".format(",".join(f"'{id}'" for id in ids))
+            soql_query += " WHERE Id IN ({})".format(",".join(f"'{id}'" for id in ids))
 
         response = _fetch_sobjects(soql_query, get_credentials())
         for entry in response.data:

--- a/server/app/salesforce_api.py
+++ b/server/app/salesforce_api.py
@@ -1,10 +1,9 @@
 import requests
 import asyncio
 import aiohttp
-from datetime import datetime, timezone
 from flask import current_app as app
 from typing import List, Dict
-from app.utils import pluck, format_error_message, group_by, get_utc_now_for_supabase
+from app.utils import pluck, format_error_message, group_by
 from app.data_models import (
     ApiResponse,
     Contact,
@@ -80,7 +79,7 @@ def fetch_salesforce_users(ids: list[str] = None) -> ApiResponse:
     api_response = ApiResponse(data=[], message="", success=False)
 
     try:
-        soql_query = "SELECT Id,Email,FirstName,LastName,Username,FullPhotoUrl,UserRole.Name FROM User WHERE IsActive = true"
+        soql_query = "SELECT Id,Email,FirstName,LastName,Username,FullPhotoUrl,UserRole.Name FROM User"
 
         if ids:
             soql_query += " AND Id IN ({})".format(",".join(f"'{id}'" for id in ids))

--- a/server/app/services/activation_service.py
+++ b/server/app/services/activation_service.py
@@ -692,7 +692,7 @@ async def compute_activated_accounts(
                             active_contact_ids=active_contact_ids,
                             last_valid_task_creator=salesforce_user_by_id.get(
                                 last_valid_task_assignee_id
-                            )[0] if last_valid_task_assignee_id in salesforce_user_by_id else all_tasks_under_account[0].get("OwnerId"),
+                            )[0],
                             last_prospecting_activity=last_prospecting_activity,
                             outbound_task_ids=task_ids,
                             qualifying_opportunity=qualifying_opportunity,


### PR DESCRIPTION
- Retrieves all users cited in Team Member Ids, even if they're inactive
- Turns off `inspect` for ngrok since its causing issues with Supabase SSL
- Parallel activation deletion for faster throughput