### PR TITLE
activation-detail-prospecting-metadata-grouping-api

### DIFF
--- a/client/src/components/Api/Api.js
+++ b/client/src/components/Api/Api.js
@@ -318,6 +318,19 @@ export const fetchSalesforceTasksByUserIds = async (userIds) => {
 };
 
 /**
+ * Fetches the prospecting activity type groupings for a given activation
+ * @param {string} activationId
+ * @returns {Promise<ApiResponse>}
+ */
+export const fetchProspectingActivityTypeGroupings = async (activationId) => {
+    const response = await api.get("/get_prospecting_activity_type_groupings", {
+        params: { activation_id: activationId },
+        validateStatus: () => true,
+    });
+    return { ...response.data, statusCode: response.status };
+};
+
+/**
  * Fetches Salesforce events from the Salesforce API
  * @param {string[]} userIds
  * @returns {Promise<ApiResponse>}

--- a/client/src/pages/Prospecting/Prospecting.js
+++ b/client/src/pages/Prospecting/Prospecting.js
@@ -27,6 +27,7 @@ import {
   getLoggedInUser,
   getUserTimezone,
   getPaginatedProspectingActivities,
+  fetchProspectingActivityTypeGroupings
 } from "src/components/Api/Api";
 import AccountDetail from "../../components/ProspectingActiveAccount/AccountDetail";
 import CustomSelect from "src/components/CustomSelect/CustomSelect";
@@ -227,6 +228,8 @@ const Prospecting = () => {
         if (response.statusCode === 200 && response.success) {
           setSummaryData(response.data[0].summary);
           setRawData(response.data[0].raw_data || []);
+          const testPmGroup = await fetchProspectingActivityTypeGroupings(response.data[0].raw_data[0].id);
+          console.log(testPmGroup);
           setOriginalRawData(response.data[0].raw_data || []);
         } else if (response.statusCode === 401) {
           navigate("/");

--- a/server/app/database/activation_selector.py
+++ b/server/app/database/activation_selector.py
@@ -346,3 +346,27 @@ def load_active_activations_paginated_with_search(
         return ApiResponse(
             success=False, message=f"Failed to load activations: {str(error_msg)}"
         )
+
+def load_single_activation_by_id(activation_id: str) -> ApiResponse:
+    supabase_client = get_supabase_admin_client()
+
+    try:
+        response = (
+            supabase_client.table("Activations")
+            .select("*")
+            .eq("id", activation_id)
+            .limit(1)
+            .execute()
+        )
+        if response.data:
+            activation = supabase_dict_to_python_activation(response.data[0])
+            return ApiResponse(data=[activation], success=True)
+        else:
+            return ApiResponse(data=[], success=False, message="Activation not found")
+    except Exception as e:
+        error_msg = format_error_message(e)
+        logging.error(f"Error in load_single_activation_by_id: {error_msg}")
+        return ApiResponse(
+            success=False, message=f"Failed to load activation: {str(error_msg)}"
+        )
+    


### PR DESCRIPTION
@ter1203 This `fetchProspectingActivityTypeGroupings` api will bring back an ordered list of ProspectingMetadata for an Activation Id. The list will be ordered by total ascending, so you should just be able to use each entry as a chart grouping, use the `total` parameter as the extent of that chart grouping. 